### PR TITLE
fix: fixed remove method of qb

### DIFF
--- a/src/utils/QueryBuilder/QueryBuilder.test.ts
+++ b/src/utils/QueryBuilder/QueryBuilder.test.ts
@@ -97,19 +97,18 @@ describe('QueryBuilder class', () => {
 
     const query = qb
       .where('name', 'John')
+      .where('name', 'Doe')
       .where('age', 25)
       .url({ encode: false });
     const matches = numberOfMatches(query, '&');
-    expect(query).toContain('filter[name]=John');
+    expect(query).toContain('filter[name]=John,Doe');
     expect(query).toContain('filter[age]=25');
     expect(query.startsWith('?')).toBeTruthy();
     expect(matches).toBe(1);
 
-    const newQuery = qb
-      .remove({ use: 'param', config: { type: 'filter', key: 'name', value: 'John' } })
-      .url({ encode: false });
+    const newQuery = qb.remove({ use: 'param', config: { type: 'filter', key: 'name' } }).url({ encode: false });
     const newMatches = numberOfMatches(newQuery, '&');
-    expect(newQuery).not.toContain('filter[name]=John');
+    expect(newQuery).not.toContain('filter[name]=John,Doe');
     expect(newQuery).toContain('filter[age]=25');
     expect(newQuery.startsWith('?')).toBeTruthy();
     expect(newMatches).toBe(0);

--- a/src/utils/QueryBuilder/QueryBuilder.ts
+++ b/src/utils/QueryBuilder/QueryBuilder.ts
@@ -168,8 +168,21 @@ export default class QueryBuilder {
 
   protected _removeParam(config: RemoveParamConfig): this {
     if (config.type === 'filter' && !!this._params.filter) {
-      this._params.filter[config.key] = this._params.filter[config.key].filter(value => value !== config.value);
-      if (this._params.filter[config.key].length === 0) delete this._params.filter[config.key];
+      if (config.value !== undefined) {
+        this._params.filter[config.key] = this._params.filter[config.key].filter(value => value !== config.value);
+      }
+      if (config.value === undefined || this._params.filter[config.key].length === 0) {
+        delete this._params.filter[config.key];
+      }
+    }
+
+    if (config.type !== 'filter') {
+      if (!!this._params[config.type]) {
+        this._params[config.type] = this._params[config.type]?.filter(value => value !== config.value);
+      }
+      if (this._params[config.type]?.length === 0) {
+        delete this._params[config.type];
+      }
     }
 
     return this;
@@ -198,7 +211,7 @@ export type HasParamConfig =
 export type RemoveConfig = { use: 'param'; config: RemoveParamConfig } | { use: 'custom'; config: RemoveCustomConfig };
 export type RemoveCustomConfig = { key: string; value: QueryValue };
 export type RemoveParamConfig =
-  | { type: 'filter'; key: string; value: QueryValue }
+  | { type: 'filter'; key: string; value?: QueryValue }
   | { type: 'include' | 'sort'; value: string };
 
 export type UrlConfig = {


### PR DESCRIPTION
- Fixed a bug where the `remove` method required a `value` eventhough I wanted to delete the `key`
- Also finished the `remove` method, cuz it was missing the case for when the `type` is not `'filter'`